### PR TITLE
feat: open reels page to selected reel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,6 @@ function App() {
               <Route path="/videos" element={<ProtectedRoute><VideosPage /></ProtectedRoute>} />
               <Route path="/videos/:id" element={<ProtectedRoute><VideoDetail /></ProtectedRoute>} />
               <Route path="/blog" element={<ProtectedRoute><BlogPage /></ProtectedRoute>} />
-              {/* <Route path="/reels/:id" element={<ProtectedRoute><ReelDetail /></ProtectedRoute>} /> */}
               <Route path="/blog/:id" element={<ProtectedRoute><BlogDetail /></ProtectedRoute>} />
               <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
 

--- a/src/components/reels/ReelCard.tsx
+++ b/src/components/reels/ReelCard.tsx
@@ -66,7 +66,7 @@ export default function ReelCard({ reel }) {
   };
 
   return (
-    <Link to={`/reels`}>      
+    <Link to="/reels" state={{ reelId: id }}>
       <Card
         className="overflow-hidden relative h-[500px]  lg:h-[500px] lg:w-[350px]"
         onMouseEnter={handleMouseEnter}

--- a/src/hooks/useReel.ts
+++ b/src/hooks/useReel.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import axiosInstance from '@/lib/axios'
 import { API_CONFIG } from '@/config/api.config'
 
@@ -7,15 +7,18 @@ export interface Reel {
   id: string
   type: 'reel'
   title: string
-  description: string
-  category: string
-  userId: string
-  views: number
-  status: string
-  createdAt: string
-  updatedAt: string
-  thumbnailUrl: string | null
-  mediaFileUrl: string
+  description?: string
+  category?: string
+  userId?: string
+  views?: number
+  status?: string
+  createdAt?: string
+  updatedAt?: string
+  thumbnailUrl?: string | null
+  mediaFileUrl?: string
+  mediaDetails?: { url: string }
+  thumbnailDetails?: { url: string }
+  likeCount?: number
 }
 
 export interface ReelsPage {
@@ -40,5 +43,17 @@ export function useReelsInfinite(limit = 10) {
       return data.data as ReelsPage
     },
     getNextPageParam: (last) => (last.hasMore ? last.currentPage + 1 : undefined),
+  })
+}
+
+export function useReel(id: string) {
+  return useQuery({
+    queryKey: ['reel', id],
+    queryFn: async () => {
+      const { data } = await axiosInstance.get(
+        API_CONFIG.ENDPOINTS.USER.REELS_DETAIL(id)
+      )
+      return data.data as Reel
+    },
   })
 }

--- a/src/pages/ReelsPage.tsx
+++ b/src/pages/ReelsPage.tsx
@@ -17,7 +17,7 @@ import ReelsNavigation from "@/components/ReelsNavigation";
 import { useReelsInfinite } from "@/hooks/useReel";
 import Layout from "@/components/Layout";
 import { Reel } from "@/types/api.types";
-import { Link } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { BounceLoader } from "react-spinners";
 
 // Use an online placeholder avatar
@@ -299,6 +299,8 @@ const ReelCard = ({ reel }: { reel: Reel }) => {
 
 export default function ReelsPage() {
   const loaderRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
+  const initialReelId = (location.state as any)?.reelId as string | undefined;
 
   const {
     data,
@@ -311,6 +313,13 @@ export default function ReelsPage() {
 
   // flatten all pages.results into one array
   const reels: Reel[] = data?.pages.flatMap((page) => page.results) ?? [];
+
+  useEffect(() => {
+    if (initialReelId) {
+      const element = document.getElementById(`reel-${initialReelId}`);
+      element?.scrollIntoView({ behavior: 'auto', block: 'start' });
+    }
+  }, [data, initialReelId]);
 
   // infinite‐scroll observer
   useEffect(() => {
@@ -374,7 +383,9 @@ export default function ReelsPage() {
       <div className="min-h-[calc(100vh-4rem)] flex flex-col items-center pt-24 px-2">
         <div className="w-full max-w-md flex flex-col gap-10">
           {reels.map((reel) => (
-            <ReelCard key={reel.id} reel={reel} />
+            <div key={reel.id} id={`reel-${reel.id}`}>
+              <ReelCard reel={reel} />
+            </div>
           ))}
 
           {/* sentinel for IntersectionObserver */}


### PR DESCRIPTION
## Summary
- route home reels to the main reels page with selected video focused
- remove unused single-reel route
- scroll reels page to the reel passed from the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 3 errors, 9 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aebbbf80a0832bbc38a491654ece08