### PR TITLE
refactor: replace BounceLoader with ClipLoader and remove loading text

### DIFF
--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BounceLoader } from 'react-spinners';
+import { ClipLoader } from 'react-spinners';
 
 interface LoaderProps {
   fullScreen?: boolean;
@@ -12,7 +12,7 @@ export default function Loader({ fullScreen = false, size = 80 }: LoaderProps) {
     : 'flex items-center justify-center';
   return (
     <div className={classes}>
-      <BounceLoader loading color="#ec4899" size={size} />
+      <ClipLoader color="#ec4899" size={size} />
     </div>
   );
 }

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import Loader from '@/components/Loader';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -10,7 +11,7 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   const location = useLocation();
 
   if (isLoading) {
-    return <div>Loading...</div>; // You can replace this with a proper loading component
+    return <Loader fullScreen />;
   }
 
   // List of public routes that don't require authentication

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useState, ReactNode, useEffect } from 'react';
 import { useProfile } from '@/hooks/api/useProfileApi';
 import type { ProfileResponse } from '@/types/profile';
+import Loader from '@/components/Loader';
 
 interface AuthContextType {
   isAuthenticated: boolean;
@@ -55,7 +56,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   if (isLoading || (token && isProfileLoading)) {
-    return <div>Loading...</div>; // You can replace this with a proper loading component
+    return <Loader fullScreen />;
   }
 
   return (

--- a/src/pages/BlogDetail.tsx
+++ b/src/pages/BlogDetail.tsx
@@ -6,6 +6,7 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import BlogCard from "@/components/blog/BlogCard";
 import { useBlog, useBlogs } from "@/hooks/useBlog";
+import Loader from "@/components/Loader";
 
 const BlogDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -21,7 +22,7 @@ const BlogDetail = () => {
       <div className="min-h-screen flex flex-col bg-background">
         <Navbar />
         <main className="flex-grow pt-16 flex items-center justify-center">
-          <span className="text-lg text-muted-foreground">Loading article...</span>
+          <Loader />
         </main>
         <Footer />
       </div>

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -2,7 +2,7 @@ import BlogCard from "@/components/blog/BlogCard";
 import FeaturedBlog from "@/components/blog/FeaturedBlog";
 import { useBlogs } from "@/hooks/useBlog";
 import Layout from "@/components/Layout";
-import { BounceLoader } from "react-spinners";
+import Loader from "@/components/Loader";
 
 const BlogPage = () => {
   const { data: featuredData } = useBlogs({ featured: true, limit: 1 });
@@ -14,16 +14,7 @@ const BlogPage = () => {
   if (isLoading) {
     return (
       <Layout>
-        {/* full‐screen backdrop */}
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
-          <BounceLoader
-            color="#ec4899"
-            loading={true}
-            size={250}
-            aria-label="Loading content"
-            data-testid="bounce-loader"
-          />
-        </div>
+        <Loader fullScreen size={250} />
       </Layout>
     );
   }

--- a/src/pages/FeaturedVideos.tsx
+++ b/src/pages/FeaturedVideos.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { usePaginatedContent } from "@/hooks/useHome";  // adjust path if needed
 import VideoCard from "@/components/videos/VideoCard";
-import { BounceLoader } from "react-spinners";
+import Loader from "@/components/Loader";
 import { Video } from "@/types/api.types";
 
 export default function FeaturedVideos({
@@ -36,7 +36,7 @@ export default function FeaturedVideos({
   if (isLoading) {
     return (
       <div className="py-12 flex justify-center">
-        <BounceLoader size={50} color="#ec4899" />
+        <Loader size={50} />
       </div>
     );
   }

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -34,6 +34,7 @@ import { useCategories } from "@/hooks/useCategories";
 import VideoCard from "@/components/videos/VideoCard";
 import ReelCard from "@/components/reels/ReelCard";
 import { toast } from "sonner";
+import Loader from "@/components/Loader";
 
 const TABS = [
   { key: "posts", label: "Posts", icon: User },
@@ -297,7 +298,11 @@ const ProfilePage = () => {
   };
 
   if (!profile) {
-    return <div>Loading...</div>;
+    return (
+      <Layout>
+        <Loader fullScreen />
+      </Layout>
+    );
   }
 
   const handleTagKeyDown = (e) => {
@@ -450,8 +455,8 @@ const ProfilePage = () => {
                 </div>
               )}
               {videosLoading ? (
-                <div className="text-center text-base sm:text-lg text-muted-foreground">
-                  Loading...
+                <div className="flex justify-center">
+                  <Loader size={40} />
                 </div>
               ) : videosData?.results && videosData.results.length > 0 ? (
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -482,8 +487,8 @@ const ProfilePage = () => {
                 </div>
               )}
               {reelsLoading ? (
-                <div className="text-center text-base sm:text-lg text-muted-foreground">
-                  Loading...
+                <div className="flex justify-center">
+                  <Loader size={40} />
                 </div>
               ) : reelsData?.results && reelsData.results.length > 0 ? (
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/pages/ReelsPage.tsx
+++ b/src/pages/ReelsPage.tsx
@@ -7,7 +7,7 @@ import Layout from "@/components/Layout";
 import ReelsNavigation from "@/components/ReelsNavigation";
 import { useReelsInfinite } from "@/hooks/useReel";
 import { ReelCard } from "@/components/reels/ReelCard2";
-import { BounceLoader } from "react-spinners";
+import Loader from "@/components/Loader";
 
 export default function ReelsPage() {
   const loaderRef = useRef<HTMLDivElement>(null);
@@ -67,9 +67,7 @@ export default function ReelsPage() {
   if (isLoading) {
     return (
       <Layout hideFooter>
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <BounceLoader loading color="#ec4899" size={100}/>
-        </div>
+        <Loader fullScreen size={100} />
       </Layout>
     );
   }

--- a/src/pages/TrendingReels.tsx
+++ b/src/pages/TrendingReels.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { BounceLoader } from "react-spinners";
+import Loader from "@/components/Loader";
 import { usePaginatedContent } from "@/hooks/useHome";
 import ReelCard from "@/components/reels/ReelCard";
 // import { YourReelType } from "@/types/api";
@@ -39,7 +39,7 @@ export default function TrendingReels({
   if (isLoading) {
     return (
       <div className="py-12 flex justify-center">
-        <BounceLoader size={50} color="#ec4899" />
+        <Loader size={50} />
       </div>
     );
   }

--- a/src/pages/TrendingVideos.tsx
+++ b/src/pages/TrendingVideos.tsx
@@ -1,6 +1,6 @@
 // components/TrendingVideos.tsx
 import { useState } from "react";
-import { BounceLoader } from "react-spinners";
+import Loader from "@/components/Loader";
 import { usePaginatedContent } from "@/hooks/useHome";
 import VideoCard from "@/components/videos/VideoCard";
 import { Video } from "@/types/api.types";
@@ -31,7 +31,7 @@ export default function TrendingVideos({
   if (isLoading) {
     return (
       <div className="py-12 flex justify-center">
-        <BounceLoader size={50} color="#ec4899" />
+        <Loader size={50} />
       </div>
     );
   }

--- a/src/pages/VideoDetail.tsx
+++ b/src/pages/VideoDetail.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import { useVideo, useVideos } from "@/hooks/useVideo";
 import Layout from "@/components/Layout";
+import Loader from "@/components/Loader";
 import {
   useRef,
   useEffect,
@@ -78,7 +79,12 @@ export default function VideoDetail() {
     setHasScrolled(false);
   }, [id]);
 
-  if (isLoading) return <Layout>Loading…</Layout>;
+  if (isLoading)
+    return (
+      <Layout>
+        <Loader />
+      </Layout>
+    );
   if (isError || !video)
     return (
       <Layout>

--- a/src/pages/VideosPage.tsx
+++ b/src/pages/VideosPage.tsx
@@ -3,7 +3,7 @@ import VideoCard from "@/components/videos/VideoCard";
 import { useVideos } from "@/hooks/useVideo";
 import Layout from "@/components/Layout";
 import { Button } from "@/components/ui/button";
-import { BounceLoader } from "react-spinners";
+import Loader from "@/components/Loader";
 import { useSearchParams } from "react-router-dom";
 import CategoryNav from "@/components/CategoryNav";
 
@@ -28,16 +28,7 @@ const VideosPage = () => {
   if (isLoading) {
     return (
       <Layout>
-        {/* full‐screen backdrop */}
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
-          <BounceLoader
-            color="#ec4899"
-            loading={true}
-            size={250}
-            aria-label="Loading content"
-            data-testid="bounce-loader"
-          />
-        </div>
+        <Loader fullScreen size={250} />
       </Layout>
     );
   }


### PR DESCRIPTION
## Summary
- replace BounceLoader with ClipLoader in shared Loader component
- use Loader component across pages and context to remove plain "Loading..." text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af21024ba0832b9d81ac75bf82dedc