### PR TITLE
Hide earn banner after login and add consent prompts

### DIFF
--- a/src/components/AgeConsentCard.tsx
+++ b/src/components/AgeConsentCard.tsx
@@ -1,0 +1,43 @@
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ShieldAlert } from 'lucide-react';
+
+interface AgeConsentCardProps {
+  open: boolean;
+  onConfirm: () => void;
+}
+
+export default function AgeConsentCard({ open, onConfirm }: AgeConsentCardProps) {
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent className="sm:max-w-md border-none p-0 bg-transparent">
+        <Card className="bg-gradient-to-b from-pink-50 to-white border-pink-200">
+          <CardHeader className="text-center space-y-2">
+            <ShieldAlert className="mx-auto h-10 w-10 text-pink-600" />
+            <CardTitle className="text-pink-700 text-2xl">Age Verification</CardTitle>
+          </CardHeader>
+          <CardContent className="text-center">
+            <p className="text-gray-700">
+              You must be 18 or older to use this platform.
+            </p>
+          </CardContent>
+          <CardFooter>
+            <Button
+              className="w-full bg-pink-600 hover:bg-pink-700 text-white"
+              onClick={onConfirm}
+            >
+              I am 18 or older
+            </Button>
+          </CardFooter>
+        </Card>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/CookieConsentCard.tsx
+++ b/src/components/CookieConsentCard.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Cookie } from 'lucide-react';
+
+interface CookieConsentCardProps {
+  onAccept: () => void;
+}
+
+export default function CookieConsentCard({ onAccept }: CookieConsentCardProps) {
+  return (
+    <div className="flex justify-center p-4">
+      <Card className="w-full max-w-md bg-pink-50 border-pink-200">
+        <CardContent className="p-4 flex items-start gap-3">
+          <Cookie className="h-5 w-5 text-pink-600 mt-1" />
+          <p className="text-sm text-gray-700">
+            We use cookies to improve your experience. By continuing, you accept our cookie policy.
+          </p>
+        </CardContent>
+        <CardFooter className="p-4 pt-0 flex justify-end">
+          <Button
+            size="sm"
+            className="bg-pink-600 hover:bg-pink-700 text-white"
+            onClick={onAccept}
+          >
+            Accept
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,10 +1,11 @@
- 
-// components/Layout.tsx
 import { ReactNode, useState, useRef, useEffect } from 'react';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import EarnBanner from './EarnBanner';
+import AgeConsentCard from './AgeConsentCard';
+import CookieConsentCard from './CookieConsentCard';
 import { useLocation } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 
 interface LayoutProps {
   children: ReactNode;
@@ -12,18 +13,34 @@ interface LayoutProps {
 }
 
 const Layout = ({ children, hideFooter = false }: LayoutProps) => {
-  const [bannerVisible, setBannerVisible] = useState(true);
+  const { isAuthenticated } = useAuth();
+  const [bannerVisible, setBannerVisible] = useState(!isAuthenticated);
+  const [showAgeConsent, setShowAgeConsent] = useState(false);
+  const [showCookieConsent, setShowCookieConsent] = useState(false);
   const bannerRef = useRef<HTMLDivElement>(null);
-  const navRef    = useRef<HTMLDivElement>(null);
+  const navRef = useRef<HTMLDivElement>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
-  const location = useLocation()
-  const isReels = location.pathname === '/reels';  
+  const location = useLocation();
+  const isReels = location.pathname === '/reels';
 
+  useEffect(() => {
+    const ageDone = localStorage.getItem('ageConsented');
+    const cookieDone = localStorage.getItem('cookiesAccepted');
+    if (!ageDone) {
+      setShowAgeConsent(true);
+    } else if (!cookieDone) {
+      setShowCookieConsent(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    setBannerVisible(!isAuthenticated);
+  }, [isAuthenticated]);
 
   useEffect(() => {
     const measure = () => {
       let h = 0;
-      if (bannerVisible && bannerRef.current) {
+      if (!isAuthenticated && bannerVisible && bannerRef.current) {
         h += bannerRef.current.getBoundingClientRect().height;
       }
       if (navRef.current) {
@@ -34,29 +51,50 @@ const Layout = ({ children, hideFooter = false }: LayoutProps) => {
     measure();
     window.addEventListener('resize', measure);
     return () => window.removeEventListener('resize', measure);
-  }, [bannerVisible]);
+  }, [bannerVisible, isAuthenticated]);
+
+  const handleAgeConfirm = () => {
+    localStorage.setItem('ageConsented', 'true');
+    setShowAgeConsent(false);
+    if (!localStorage.getItem('cookiesAccepted')) {
+      setShowCookieConsent(true);
+    }
+  };
+
+  const handleCookieAccept = () => {
+    localStorage.setItem('cookiesAccepted', 'true');
+    setShowCookieConsent(false);
+  };
 
   return (
-    <div className="min-h-screen flex flex-col bg-background"
-          style={
-        isReels
-          ? { '--header-height': `${headerHeight}px` } as React.CSSProperties
-          : {}
-      }>
-      <div ref={bannerRef}>
-        {bannerVisible && <EarnBanner onClose={() => setBannerVisible(false)} />}
-      </div>
-      <div ref={navRef}>
-        <Navbar />
-      </div>
+    <>
+      <AgeConsentCard open={showAgeConsent} onConfirm={handleAgeConfirm} />
+      <div
+        className="min-h-screen flex flex-col bg-background"
+        style={
+          isReels
+            ? ({ '--header-height': `${headerHeight}px` } as React.CSSProperties)
+            : {}
+        }
+      >
+        <div ref={bannerRef}>
+          {!isAuthenticated && bannerVisible && (
+            <EarnBanner onClose={() => setBannerVisible(false)} />
+          )}
+        </div>
+        <div ref={navRef}>
+          <Navbar />
+        </div>
 
-      <main className="flex-grow"
-            style={{ paddingTop: `var(--header-height)` }}>
-        {children}
-      </main>
+        <main className="flex-grow" style={{ paddingTop: `var(--header-height)` }}>
+          {children}
+        </main>
 
-      {!hideFooter && <Footer />}
-    </div>
+        {showCookieConsent && <CookieConsentCard onAccept={handleCookieAccept} />}
+
+        {!hideFooter && <Footer />}
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- hide the top earn banner once a user is authenticated
- show age verification modal on first visit until confirmed
- display a small footer cookie consent banner after age confirmation
- add color and icons to the age and cookie consent cards for a friendlier appearance

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af51445078832b8b618eaa2926e067