### PR TITLE
Hide earn banner after login and add consent prompts

### DIFF
--- a/src/components/AgeConsentCard.tsx
+++ b/src/components/AgeConsentCard.tsx
@@ -1,0 +1,57 @@
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardFooter,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ShieldAlert } from 'lucide-react';
+
+interface AgeConsentCardProps {
+  open: boolean;
+  onConfirm: () => void;
+}
+
+export default function AgeConsentCard({ open, onConfirm }: AgeConsentCardProps) {
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent className="sm:max-w-xl border-none p-0 bg-transparent">
+        <Card className="bg-gradient-to-b from-pink-50 to-white border-pink-200">
+          <CardHeader className="text-center space-y-2">
+            <ShieldAlert className="mx-auto h-10 w-10 text-pink-600" />
+            <CardTitle className="text-pink-700 text-2xl">Adults Only</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-gray-700 text-sm">
+            <p>
+              The content available on this site may include sexually explicit
+              material. Access is limited to individuals 18 years of age or
+              older, or the age of majority in your jurisdiction.
+            </p>
+            <p>
+              By entering, you confirm that you are of legal age and agree to
+              take steps to prevent minors from accessing this site using
+              parental controls or other safeguards.
+            </p>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-2 sm:flex-row">
+            <Button
+              className="w-full bg-pink-600 hover:bg-pink-700 text-white"
+              onClick={onConfirm}
+            >
+              I am 18 or older
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => (window.location.href = 'https://www.google.com')}
+            >
+              Leave site
+            </Button>
+          </CardFooter>
+        </Card>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/CookieConsentCard.tsx
+++ b/src/components/CookieConsentCard.tsx
@@ -1,0 +1,44 @@
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Card, CardContent, CardFooter } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Cookie } from 'lucide-react';
+
+interface CookieConsentCardProps {
+  open: boolean;
+  onAccept: () => void;
+  onDecline: () => void;
+}
+
+export default function CookieConsentCard({
+  open,
+  onAccept,
+  onDecline,
+}: CookieConsentCardProps) {
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent className="sm:max-w-md border-none p-0 bg-transparent">
+        <Card className="bg-pink-50 border-pink-200">
+          <CardContent className="p-4 flex items-start gap-3">
+            <Cookie className="h-5 w-5 text-pink-600 mt-1" />
+            <p className="text-sm text-gray-700">
+              We use cookies to improve your experience. You can accept or decline
+              our use of cookies.
+            </p>
+          </CardContent>
+          <CardFooter className="p-4 pt-0 flex justify-end gap-2">
+            <Button size="sm" variant="outline" onClick={onDecline}>
+              Decline
+            </Button>
+            <Button
+              size="sm"
+              className="bg-pink-600 hover:bg-pink-700 text-white"
+              onClick={onAccept}
+            >
+              Accept
+            </Button>
+          </CardFooter>
+        </Card>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,10 +1,11 @@
- 
-// components/Layout.tsx
 import { ReactNode, useState, useRef, useEffect } from 'react';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import EarnBanner from './EarnBanner';
+import AgeConsentCard from './AgeConsentCard';
+import CookieConsentCard from './CookieConsentCard';
 import { useLocation } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 
 interface LayoutProps {
   children: ReactNode;
@@ -12,18 +13,34 @@ interface LayoutProps {
 }
 
 const Layout = ({ children, hideFooter = false }: LayoutProps) => {
-  const [bannerVisible, setBannerVisible] = useState(true);
+  const { isAuthenticated } = useAuth();
+  const [bannerVisible, setBannerVisible] = useState(!isAuthenticated);
+  const [showAgeConsent, setShowAgeConsent] = useState(false);
+  const [showCookieConsent, setShowCookieConsent] = useState(false);
   const bannerRef = useRef<HTMLDivElement>(null);
-  const navRef    = useRef<HTMLDivElement>(null);
+  const navRef = useRef<HTMLDivElement>(null);
   const [headerHeight, setHeaderHeight] = useState(0);
-  const location = useLocation()
-  const isReels = location.pathname === '/reels';  
+  const location = useLocation();
+  const isReels = location.pathname === '/reels';
 
+  useEffect(() => {
+    const ageDone = localStorage.getItem('ageConsented');
+    const cookieDone = localStorage.getItem('cookiesAccepted');
+    if (!ageDone) {
+      setShowAgeConsent(true);
+    } else if (!cookieDone) {
+      setShowCookieConsent(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    setBannerVisible(!isAuthenticated);
+  }, [isAuthenticated]);
 
   useEffect(() => {
     const measure = () => {
       let h = 0;
-      if (bannerVisible && bannerRef.current) {
+      if (!isAuthenticated && bannerVisible && bannerRef.current) {
         h += bannerRef.current.getBoundingClientRect().height;
       }
       if (navRef.current) {
@@ -34,29 +51,58 @@ const Layout = ({ children, hideFooter = false }: LayoutProps) => {
     measure();
     window.addEventListener('resize', measure);
     return () => window.removeEventListener('resize', measure);
-  }, [bannerVisible]);
+  }, [bannerVisible, isAuthenticated]);
+
+  const handleAgeConfirm = () => {
+    localStorage.setItem('ageConsented', 'true');
+    setShowAgeConsent(false);
+    if (!localStorage.getItem('cookiesAccepted')) {
+      setShowCookieConsent(true);
+    }
+  };
+
+  const handleCookieAccept = () => {
+    localStorage.setItem('cookiesAccepted', 'true');
+    setShowCookieConsent(false);
+  };
+
+  const handleCookieDecline = () => {
+    localStorage.setItem('cookiesAccepted', 'false');
+    setShowCookieConsent(false);
+  };
 
   return (
-    <div className="min-h-screen flex flex-col bg-background"
-          style={
-        isReels
-          ? { '--header-height': `${headerHeight}px` } as React.CSSProperties
-          : {}
-      }>
-      <div ref={bannerRef}>
-        {bannerVisible && <EarnBanner onClose={() => setBannerVisible(false)} />}
-      </div>
-      <div ref={navRef}>
-        <Navbar />
-      </div>
+    <>
+      <AgeConsentCard open={showAgeConsent} onConfirm={handleAgeConfirm} />
+      <CookieConsentCard
+        open={showCookieConsent}
+        onAccept={handleCookieAccept}
+        onDecline={handleCookieDecline}
+      />
+      <div
+        className="min-h-screen flex flex-col bg-background"
+        style={
+          isReels
+            ? ({ '--header-height': `${headerHeight}px` } as React.CSSProperties)
+            : {}
+        }
+      >
+        <div ref={bannerRef}>
+          {!isAuthenticated && bannerVisible && (
+            <EarnBanner onClose={() => setBannerVisible(false)} />
+          )}
+        </div>
+        <div ref={navRef}>
+          <Navbar />
+        </div>
 
-      <main className="flex-grow"
-            style={{ paddingTop: `var(--header-height)` }}>
-        {children}
-      </main>
+        <main className="flex-grow" style={{ paddingTop: `var(--header-height)` }}>
+          {children}
+        </main>
 
-      {!hideFooter && <Footer />}
-    </div>
+        {!hideFooter && <Footer />}
+      </div>
+    </>
   );
 };
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/90 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- hide the top earn banner once a user is authenticated
- show age verification modal on first visit until confirmed
- display a cookie consent modal with backdrop, offering accept and decline options
- add color and icons to the age and cookie consent cards for a friendlier appearance
- darken and blur modal backdrop; expand adult-only disclaimer with exit option

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af51445078832b8b618eaa2926e067