### PR TITLE
Enable direct reel playback from home feed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import VideosPage from "./pages/VideosPage";
 import VideoDetail from "./pages/VideoDetail";
 import BlogPage from "./pages/BlogPage";
 // import ReelDetail from "./pages/ReelDetail";
+import ReelPage from "./pages/ReelPage";
 import BlogDetail from "./pages/BlogDetail";
 import NotFound from "./pages/NotFound";
 import LoginPage from "./pages/LoginPage";
@@ -41,6 +42,7 @@ function App() {
               {/* Protected Routes */}
               <Route path="/" element={<ProtectedRoute><Index /></ProtectedRoute>} />
               <Route path="/reels" element={<ProtectedRoute><ReelsPage /></ProtectedRoute>} />
+              <Route path="/reels/:id" element={<ProtectedRoute><ReelPage /></ProtectedRoute>} />
               <Route path="/videos" element={<ProtectedRoute><VideosPage /></ProtectedRoute>} />
               <Route path="/videos/:id" element={<ProtectedRoute><VideoDetail /></ProtectedRoute>} />
               <Route path="/blog" element={<ProtectedRoute><BlogPage /></ProtectedRoute>} />

--- a/src/components/reels/ReelCard.tsx
+++ b/src/components/reels/ReelCard.tsx
@@ -66,7 +66,7 @@ export default function ReelCard({ reel }) {
   };
 
   return (
-    <Link to={`/reels`}>      
+    <Link to={`/reels/${id}`}>
       <Card
         className="overflow-hidden relative h-[500px]  lg:h-[500px] lg:w-[350px]"
         onMouseEnter={handleMouseEnter}

--- a/src/hooks/useReel.ts
+++ b/src/hooks/useReel.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import axiosInstance from '@/lib/axios'
 import { API_CONFIG } from '@/config/api.config'
 
@@ -16,6 +16,9 @@ export interface Reel {
   updatedAt: string
   thumbnailUrl: string | null
   mediaFileUrl: string
+  mediaDetails?: {
+    url: string
+  }
 }
 
 export interface ReelsPage {
@@ -40,5 +43,18 @@ export function useReelsInfinite(limit = 10) {
       return data.data as ReelsPage
     },
     getNextPageParam: (last) => (last.hasMore ? last.currentPage + 1 : undefined),
+  })
+}
+
+export function useReel(id: string) {
+  return useQuery<Reel, Error>({
+    queryKey: ['reel', id],
+    queryFn: async () => {
+      const { data } = await axiosInstance.get(
+        API_CONFIG.ENDPOINTS.USER.REELS_DETAIL(id)
+      )
+      return data.data as Reel
+    },
+    enabled: !!id,
   })
 }

--- a/src/pages/ReelPage.tsx
+++ b/src/pages/ReelPage.tsx
@@ -11,7 +11,9 @@ export default function ReelPage() {
   const navigate = useNavigate();
   const { data: reel, isLoading, isError } = useReel(id!);
   const videoRef = useRef<HTMLVideoElement>(null);
-  const duration = useVideoDuration(reel?.mediaFileUrl || '');
+  const duration = useVideoDuration(
+    reel?.mediaFileUrl || reel?.mediaDetails?.url || ''
+  );
   const [muted, setMuted] = React.useState(true);
 
   useEffect(() => {
@@ -19,6 +21,10 @@ export default function ReelPage() {
       videoRef.current.muted = muted;
     }
   }, [muted]);
+
+  useEffect(() => {
+    videoRef.current?.play().catch(() => {});
+  }, [reel]);
 
   if (isLoading) return <p>Loading reel...</p>;
   if (isError || !reel) return <p>Failed to load reel.</p>;
@@ -32,10 +38,12 @@ export default function ReelPage() {
       <div className="relative rounded-lg overflow-hidden bg-black">
         <video
           ref={videoRef}
-          src={reel.mediaDetails.url}
+          src={reel.mediaDetails?.url || reel.mediaFileUrl}
           controls
           loop
           playsInline
+          autoPlay
+          muted={muted}
           className="w-full h-auto"
         />
         <div className="absolute bottom-2 right-2 bg-black/70 text-white text-xs px-2 py-1 rounded">


### PR DESCRIPTION
## Summary
- Add `useReel` hook to fetch individual reels
- Route and autoplay a single reel page
- Link reel cards to their detail page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype, 'vid' is never reassigned. Use 'const' instead)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a16eab60832bafb111f955b9a2fb