### PR TITLE
feat: add review counts and delay view increments

### DIFF
--- a/src/components/reels/ReelCard2.tsx
+++ b/src/components/reels/ReelCard2.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import ReelVideoPlayer from "@/components/HlsReel";
 import { Reel } from "@/types/api.types";
+import { useIncrementReelView } from "@/hooks/useReel";
 
 const avatar =
   "https://ui-avatars.com/api/?name=User&background=6c47ff&color=fff";
@@ -31,6 +32,8 @@ interface Comment {
 export function ReelCard({ reel }: { reel: Reel }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const hasIncremented = useRef(false);
+  const { mutate: incrementView } = useIncrementReelView();
 
   const [muted, setMuted] = useState(true);
   const [playing, setPlaying] = useState(false);
@@ -122,6 +125,19 @@ export function ReelCard({ reel }: { reel: Reel }) {
     setInput("");
   };
 
+  const VIEW_INCREMENT_THRESHOLD = 20;
+
+  const handleTimeUpdate = (e: React.SyntheticEvent<HTMLVideoElement>) => {
+    if (
+      !hasIncremented.current &&
+      reel._id &&
+      e.currentTarget.currentTime >= VIEW_INCREMENT_THRESHOLD
+    ) {
+      incrementView(reel._id);
+      hasIncremented.current = true;
+    }
+  };
+
   return (
     <Card
       ref={containerRef}
@@ -149,6 +165,7 @@ export function ReelCard({ reel }: { reel: Reel }) {
               setPlaying(false);
               setShowReplay(true);
             }}
+            onTimeUpdate={handleTimeUpdate}
           />
         ) : (
           <img

--- a/src/components/videos/VideoCard.tsx
+++ b/src/components/videos/VideoCard.tsx
@@ -3,8 +3,8 @@
 
 import { Link } from "react-router-dom";
 import { Card } from "@/components/ui/card";
-import { useRef, useState } from "react";
-import { formatDuration } from "@/lib/utils";
+import { useState } from "react";
+import { formatDuration, formatCount } from "@/lib/utils";
 
 export default function VideoCard({ v }: any) {
   const {
@@ -17,8 +17,13 @@ export default function VideoCard({ v }: any) {
   } = v;
 
   const duration = formatDuration(lengthSec);
-  const videoRef = useRef<HTMLVideoElement>(null);
   const [hovered, setHovered] = useState(false);
+
+  const views = v.stats?.views ?? v.views ?? 0;
+  const reviews =
+    v.stats?.comments ?? v.stats?.reviews ?? v.reviewCount ?? 0;
+  const formattedViews = formatCount(views);
+  const formattedReviews = formatCount(reviews);
 
   return (
     <Link to={`/videos/${id}`}>
@@ -51,7 +56,9 @@ export default function VideoCard({ v }: any) {
           <h3 className="font-medium mb-2 line-clamp-2 truncate">{title}</h3>
           <div className="mt-auto flex justify-between text-sm text-card-foreground/70">
             <span>{author || "Unknown"}</span>
-            <span>0 views</span>
+            <span>
+              {formattedViews} views • {formattedReviews} reviews
+            </span>
           </div>
         </div>
       </Card>

--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -74,6 +74,9 @@ export const API_CONFIG = {
       LIKED_MEDIA: '/media/liked',
       CATEGORIES: '/media/categories',
     },
+    REELS: {
+      INCREMENT_VIEW: (id: string) => `/reels/${id}/view`,
+    },
     // Blog
     BLOG: {
       LIST: '/user/blogs',

--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -75,7 +75,7 @@ export const API_CONFIG = {
       CATEGORIES: '/media/categories',
     },
     REELS: {
-      INCREMENT_VIEW: (id: string) => `/reels/${id}/view`,
+      INCREMENT_VIEW: (id: string) => `/user/reels/${id}/view`,
     },
     // Blog
     BLOG: {

--- a/src/hooks/useReel.ts
+++ b/src/hooks/useReel.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axiosInstance from '@/lib/axios'
 import { API_CONFIG } from '@/config/api.config'
 import type { Reel } from '@/types/api.types'
@@ -26,5 +26,22 @@ export function useReelsInfinite(limit = 10, startKey?: string) {
       return data.data as ReelsPage
     },
     getNextPageParam: (last) => (last.hasMore ? last.currentPage + 1 : undefined),
+  })
+}
+
+export const useIncrementReelView = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { data } = await axiosInstance.put(
+        API_CONFIG.ENDPOINTS.REELS.INCREMENT_VIEW(id)
+      )
+      return data.data
+    },
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: ['reels'] })
+      queryClient.invalidateQueries({ queryKey: ['reel', id] })
+    },
   })
 }

--- a/src/hooks/useVideo.ts
+++ b/src/hooks/useVideo.ts
@@ -118,4 +118,21 @@ export const useSaveVideo = () => {
       queryClient.invalidateQueries({ queryKey: ['videos'] });
     },
   });
-}; 
+};
+
+export const useIncrementVideoView = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const response = await axiosInstance.put(
+        API_CONFIG.ENDPOINTS.MEDIA.INCREMENT_VIEW(id)
+      );
+      return response.data.data;
+    },
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: ["video", id] });
+      queryClient.invalidateQueries({ queryKey: ["videos"] });
+    },
+  });
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -33,6 +33,16 @@ export function formatDuration(totalSeconds: number): string {
   }
 }
 
+export function formatCount(count: number): string {
+  if (count >= 1e6) {
+    return `${(count / 1e6).toFixed(1)}M`;
+  }
+  if (count >= 1e3) {
+    return `${(count / 1e3).toFixed(1)}K`;
+  }
+  return `${count}`;
+}
+
 
 export function setCookie(name: string, value: string, days: number = 7) {
   const expires = new Date();

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -128,9 +128,7 @@ export interface Video {
     _id: string;
     name: string;
   };
-  stats?: {
-    views: number;
-  };
+  stats?: Stats;
   id?: string;
   description?: string;
   username?: string;


### PR DESCRIPTION
## Summary
- show review totals for videos with new formatCount helper
- display formatted review and view counts on video cards and detail pages
- increment view count only after 20 seconds of playback to reflect genuine views
- track reel views through `/reels/:id/view` once 20 seconds are watched

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0b505510c832b9884c3ed5f95d332