### PR TITLE
Prevent refetch on reel view update and handle short reel durations

### DIFF
--- a/src/components/reels/ReelCard2.tsx
+++ b/src/components/reels/ReelCard2.tsx
@@ -125,7 +125,7 @@ export function ReelCard({ reel }: { reel: Reel }) {
     setInput("");
   };
 
-  const VIEW_INCREMENT_THRESHOLD = 20;
+  const VIEW_INCREMENT_THRESHOLD = Math.min(20, reel.lengthSec || 20);
 
   const handleTimeUpdate = (e: React.SyntheticEvent<HTMLVideoElement>) => {
     if (


### PR DESCRIPTION
## Summary
- Avoid refetching the reels list when incrementing views by updating cached data directly
- Trigger view API earlier for short reels by using their actual length

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3bb3fb9f4832bb8c12d522cc58793