### PR TITLE
Add reel progress indicator and prevent refetch on view update

### DIFF
--- a/src/components/reels/ReelScrubber.tsx
+++ b/src/components/reels/ReelScrubber.tsx
@@ -1,0 +1,17 @@
+interface ReelScrubberProps {
+  progress: number; // 0 to 1
+}
+
+const ReelScrubber = ({ progress }: ReelScrubberProps) => {
+  const clamped = Math.min(Math.max(progress, 0), 1);
+  return (
+    <div className="absolute top-0 left-0 w-full h-1 bg-white/20 z-30">
+      <div
+        className="h-full bg-reel-purple-500 transition-all"
+        style={{ width: `${clamped * 100}%` }}
+      />
+    </div>
+  );
+};
+
+export default ReelScrubber;


### PR DESCRIPTION
## Summary
- Avoid refetching the reels list when incrementing views by updating cached data directly
- Trigger view API earlier for short reels by using their actual length
- Display playback progress with a new ReelScrubber overlay

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3bb3fb9f4832bb8c12d522cc58793